### PR TITLE
#166212925 Update root URL to reflect Swaggger

### DIFF
--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -6,5 +6,5 @@ Rswag::Ui.configure do |c|
   # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON endpoints,
   # then the list below should correspond to the relative paths for those endpoints
 
-  c.swagger_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'
+  c.swagger_endpoint '/v1/swagger.json', 'API V1 Docs'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  mount Rswag::Ui::Engine => '/api-docs'
-  mount Rswag::Api::Engine => '/api-docs'
+  mount Rswag::Ui::Engine => '/'
+  mount Rswag::Api::Engine => '/'
   post "/graphql", to: "graphql#execute"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -16,7 +16,7 @@ RSpec.configure do |config|
     'v1/swagger.json' => {
       swagger: '2.0',
       info: {
-        title: 'API V1',
+        title: 'Authors Haven',
         version: 'v1'
       },
       paths: {}

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "API V1",
+    "title": "Authors Haven",
     "version": "v1"
   },
   "paths": {


### PR DESCRIPTION
#### What does this PR do?

Updates the root URL to reflect swagger documentation

#### Description of Task to be completed?

1. Update the root URL to reflect swagger documentation
#### How should this be manually tested?

1. Checkout to this branch `ft-document-api-using-swagger-166212925`
2. Run `rails s` to start the server
3. Visit the homepage `localhost:3000` where you should be able to view the swagger documentation

#### Any background context you want to provide?

The chore done before did not reflect the documentation in the home page

#### What are the relevant pivotal tracker stories?

[#166212925](https://www.pivotaltracker.com/story/show/166212925)

#### Screenshots (if appropriate)

<img width="504" alt="Screenshot 2019-06-16 at 12 24 52" src="https://user-images.githubusercontent.com/25789307/59562150-c38b6300-9031-11e9-8f51-a096e36db8a4.png">

